### PR TITLE
Fix slim skin shoulders

### DIFF
--- a/src/main/java/pl/js6pak/mojangfix/client/skinfix/PlayerEntityModel.java
+++ b/src/main/java/pl/js6pak/mojangfix/client/skinfix/PlayerEntityModel.java
@@ -31,16 +31,16 @@ public class PlayerEntityModel extends BipedEntityModel {
         if (thinArms) {
             this.leftArm = this.createModelPart(32, 48);
             this.leftArm.addCuboid(-1.0F, -2.0F, -2.0F, 3, 12, 4, scale);
-            this.leftArm.setPivot(5.0F, 2.5F, 0.0F);
+            this.leftArm.setPivot(5.0F, 2.0F, 0.0F);
             this.rightArm = this.createModelPart(40, 16);
             this.rightArm.addCuboid(-2.0F, -2.0F, -2.0F, 3, 12, 4, scale);
-            this.rightArm.setPivot(-5.0F, 2.5F, 0.0F);
+            this.rightArm.setPivot(-5.0F, 2.0F, 0.0F);
             this.leftSleeve = this.createModelPart(48, 48);
             this.leftSleeve.addCuboid(-1.0F, -2.0F, -2.0F, 3, 12, 4, scale + 0.25F);
-            this.leftSleeve.setPivot(5.0F, 2.5F, 0.0F);
+            this.leftSleeve.setPivot(5.0F, 2.0F, 0.0F);
             this.rightSleeve = this.createModelPart(40, 32);
             this.rightSleeve.addCuboid(-2.0F, -2.0F, -2.0F, 3, 12, 4, scale + 0.25F);
-            this.rightSleeve.setPivot(-5.0F, 2.5F, 10.0F);
+            this.rightSleeve.setPivot(-5.0F, 2.0F, 10.0F);
         } else {
             this.leftArm = this.createModelPart(32, 48);
             this.leftArm.addCuboid(-1.0F, -2.0F, -2.0F, 4, 12, 4, scale);


### PR DESCRIPTION
So if you've noticed the shoulders of the slim skins in Minecraft are bellow the chest by a pixel unlike classic skins.

- You will fix a bug that is still in the latest version of the game
- I will be extremely happy cause my mod will be compatible
